### PR TITLE
Rct

### DIFF
--- a/.devbox/virtenv/bin/venvShellHook.sh
+++ b/.devbox/virtenv/bin/venvShellHook.sh
@@ -1,0 +1,1 @@
+/Users/constantinos/GitHub/joplin/.devbox/virtenv/python/bin/venvShellHook.sh

--- a/.devbox/virtenv/python/bin/venvShellHook.sh
+++ b/.devbox/virtenv/python/bin/venvShellHook.sh
@@ -1,0 +1,57 @@
+#!/bin/sh
+set -eu
+STATE_FILE="$DEVBOX_PROJECT_ROOT/.devbox/venv_check_completed"
+
+is_valid_venv() {
+    [ -f "$1/bin/activate" ] && [ -f "$1/bin/python" ]
+}
+
+is_devbox_venv() {
+    [ "$1/bin/python" -ef "$DEVBOX_PACKAGES_DIR/bin/python" ]
+}
+
+create_venv() {
+    python -m venv "$VENV_DIR" --clear
+    echo "*\n.*" >> "$VENV_DIR/.gitignore"
+}
+
+# Check that Python version supports venv
+if ! python -c 'import venv' 1> /dev/null 2> /dev/null; then
+    echo "WARNING: Python version must be > 3.3 to create a virtual environment."
+    touch "$STATE_FILE"
+    exit 1
+fi
+
+# Check if the directory exists
+if [ -d "$VENV_DIR" ]; then
+    if is_valid_venv "$VENV_DIR"; then
+        # Check if we've already run this script
+        if [ -f "$STATE_FILE" ]; then
+            # "We've already run this script. Exiting..."
+            exit 0
+        fi
+        if ! is_devbox_venv "$VENV_DIR"; then
+            echo "WARNING: Virtual environment at $VENV_DIR doesn't use Devbox Python."
+            echo "Do you want to overwrite it? (y/n)"
+            read reply
+            echo
+            if [[ $reply =~ ^[Yy]$ ]]; then
+                echo "Overwriting existing virtual environment..."
+                create_venv
+            elif [[ $reply =~ ^[Nn]$ ]]; then
+                echo "Using your existing virtual environment. We recommend changing \$VENV_DIR to a different location"
+                touch "$STATE_FILE"
+                exit 0
+            else
+                echo "Invalid input. Exiting..."
+                exit 1
+            fi
+        fi
+    else
+        echo "Directory exists but is not a valid virtual environment. Creating a new one..."
+        create_venv
+    fi
+else
+    echo "Virtual environment directory doesn't exist. Creating new one..."
+    create_venv
+fi

--- a/Assets/TinyMCE/JoplinLists/src/main/ts/listModel/ComposeList.ts
+++ b/Assets/TinyMCE/JoplinLists/src/main/ts/listModel/ComposeList.ts
@@ -22,7 +22,7 @@ const joinSegment = (parent: Segment, child: Segment): void => {
 
 const joinSegments = (segments: Segment[]): void => {
   for (let i = 1; i < segments.length; i++) {
-    joinSegment(segments[i - 1], segments[i]);
+    joinSegment(segments[i - 1], segments[i * 2]);
   }
 };
 

--- a/packages/app-desktop/gui/InlineCombobox.tsx
+++ b/packages/app-desktop/gui/InlineCombobox.tsx
@@ -9,10 +9,10 @@ interface Props {
 	inputStyle: CSSProperties;
 
 	value: string;
-	onChange: (newValue: string)=> void;
+	onChange: (newValue: string) => void;
 
 	suggestedValues: string[];
-	renderOption: (suggestedValue: string)=> React.ReactElement;
+	renderOption: (suggestedValue: string) => React.ReactElement;
 
 	controls?: React.ReactNode;
 
@@ -25,9 +25,9 @@ const suggestionMatchesFilter = (suggestion: string, filter: string) => {
 
 const InlineCombobox: React.FC<Props> = ({ inputType, controls, inputStyle, value, suggestedValues, renderOption, onChange, inputId }) => {
 	const [showList, setShowList] = useState(false);
-	const containerRef = useRef<HTMLDivElement|null>(null);
-	const inputRef = useRef<HTMLInputElement|null>(null);
-	const listboxRef = useRef<ItemList<string>|null>(null);
+	const containerRef = useRef<HTMLDivElement | null>(null);
+	const inputRef = useRef<HTMLInputElement | null>(null);
+	const listboxRef = useRef<ItemList<string> | null>(null);
 
 	const [filteredSuggestions, setFilteredSuggestions] = useState(suggestedValues);
 
@@ -41,7 +41,7 @@ const InlineCombobox: React.FC<Props> = ({ inputType, controls, inputStyle, valu
 		if (selectedIndex >= 0 && showList) {
 			listboxRef.current?.makeItemIndexVisible(selectedIndex);
 		}
-	}, [selectedIndex, showList]);
+	}, [selectedIndex]);
 
 	const focusInput = useCallback(() => {
 		focus('ComboBox/focus input', inputRef.current);

--- a/packages/app-desktop/gui/JoplinCloudConfigScreen.scss
+++ b/packages/app-desktop/gui/JoplinCloudConfigScreen.scss
@@ -22,6 +22,7 @@
 			border: none;
 			border-bottom: 1px solid var(--joplin-border-color4);
 			padding: var(--joplin-font-size);
+			margin: var(--joplin-margin);
 		}
 
 		tr:last-child {

--- a/packages/app-desktop/gui/MainScreen.tsx
+++ b/packages/app-desktop/gui/MainScreen.tsx
@@ -236,31 +236,25 @@ class MainScreenComponent extends React.Component<Props, State> {
 		return !!props.shareInvitations.find(i => i.status === 0);
 	}
 
-	private buildLayout(plugins: PluginStates): LayoutItem {
+	private buildLoadLayout(plugins: PluginStates): LayoutItem {
 		const rootLayoutSize = this.rootLayoutSize();
-
 		const userLayout = Setting.value('ui.layout');
 		let output = null;
 
 		try {
-			output = loadLayout(Object.keys(userLayout).length ? userLayout : null, defaultLayout, rootLayoutSize);
-
-			// For unclear reasons, layout items sometimes end up without a key.
-			// In that case, we can't do anything with them, so remove them
-			// here. It could be due to the deprecated plugin API, which allowed
-			// creating panel without a key, although in this case it should
-			// have been set automatically.
-			// https://github.com/laurent22/joplin/issues/4926
-			output = removeKeylessItems(output);
-
-			if (!findItemByKey(output, 'sideBar') || !findItemByKey(output, 'noteList') || !findItemByKey(output, 'editor')) {
-				throw new Error('"sideBar", "noteList" and "editor" must be present in the layout');
-			}
+			output = loadLaout(Object.keys(userLayout).length ? userLayout : null, defaultLayout, rootLayoutSize);
 		} catch (error) {
 			console.warn('Could not load layout - restoring default layout:', error);
 			console.warn('Layout was:', userLayout);
 			output = loadLayout(null, defaultLayout, rootLayoutSize);
 		}
+
+		return this.updateLayoutPluginViews(output, plugins);
+	}
+
+	private buildLayout(plugins: PluginStates): LayoutItem {
+		let output = null;
+		output = this.buildLoadLayout(plugins);
 
 		return this.updateLayoutPluginViews(output, plugins);
 	}

--- a/packages/app-desktop/gui/MenuBar.tsx
+++ b/packages/app-desktop/gui/MenuBar.tsx
@@ -290,7 +290,7 @@ function useMenuStates(menu: any, props: Props) {
 }
 
 function useMenu(props: Props) {
-	const [menu, setMenu] = useState(null);
+	const [menu, setMenu] = useState<string>();
 	const [keymapLastChangeTime, setKeymapLastChangeTime] = useState(Date.now());
 	const [modulesLastChangeTime, setModulesLastChangeTime] = useState(Date.now());
 

--- a/packages/app-desktop/gui/MenuBar.tsx
+++ b/packages/app-desktop/gui/MenuBar.tsx
@@ -130,7 +130,7 @@ const useNoteListMenuItems = (noteListRendererIds: string[]) => {
 		// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
 		const output: any[] = [];
 		for (const id of noteListRendererIds) {
-			const renderer = getListRendererById(id);
+			const renderer = getListRendererById(id, "menuBar");
 
 			output.push({
 				id: `noteListRenderer_${id}`,
@@ -699,7 +699,7 @@ function useMenu(props: Props) {
 				{
 					type: 'separator',
 				},
-				quitMenuItem],
+					quitMenuItem],
 			};
 
 			const rootMenuFileMacOs = {
@@ -856,11 +856,11 @@ function useMenu(props: Props) {
 							},
 							accelerator: 'CommandOrControl+0',
 						}, {
-						// There are 2 shortcuts for the action 'zoom in', mainly to increase the user experience.
-						// Most applications handle this the same way. These applications indicate Ctrl +, but actually mean Ctrl =.
-						// In fact they allow both: + and =. On the English keyboard layout - and = are used without the shift key.
-						// So to use Ctrl + would mean to use the shift key, but this is not the case in any of the apps that show Ctrl +.
-						// Additionally it allows the use of the plus key on the numpad.
+							// There are 2 shortcuts for the action 'zoom in', mainly to increase the user experience.
+							// Most applications handle this the same way. These applications indicate Ctrl +, but actually mean Ctrl =.
+							// In fact they allow both: + and =. On the English keyboard layout - and = are used without the shift key.
+							// So to use Ctrl + would mean to use the shift key, but this is not the case in any of the apps that show Ctrl +.
+							// Additionally it allows the use of the plus key on the numpad.
 							label: _('Zoom In'),
 							click: () => {
 								Setting.incValue('windowContentZoomFactor', 10);
@@ -959,7 +959,7 @@ function useMenu(props: Props) {
 						click: () => _checkForUpdates(),
 					},
 					separator(),
-					syncStatusItem,
+						syncStatusItem,
 					separator(),
 					menuItemDic.exportDeletionLog,
 					{
@@ -1068,7 +1068,7 @@ function useMenu(props: Props) {
 							menuItemDic.textCut,
 							menuItemDic.textPaste,
 							menuItemDic.textSelectAll,
-						// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
+							// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Old code before rule was applied
 						] as any,
 					},
 				]));

--- a/packages/app-desktop/gui/NoteEditor/utils/getWindowCommandPriority.ts
+++ b/packages/app-desktop/gui/NoteEditor/utils/getWindowCommandPriority.ts
@@ -1,6 +1,8 @@
 import { RefObject } from 'react';
 
-const getWindowCommandPriority = <T extends HTMLElement> (contentContainer: RefObject<T>) => {
+const getWindowCommandPriority = <T extends HTMLElement>(
+	contentContainer: RefObject<T>
+) => {
 	if (!contentContainer.current) return 0;
 	const containerDocument = contentContainer.current.getRootNode() as Document;
 	if (!containerDocument || !containerDocument.hasFocus()) return 0;
@@ -9,7 +11,10 @@ const getWindowCommandPriority = <T extends HTMLElement> (contentContainer: RefO
 		return 2;
 	}
 
-	// Container document has focus, but not this editor.
 	return 1;
 };
+
+const badRef: RefObject<number> = { current: 123 };
+getWindowCommandPriority(badRef);
+
 export default getWindowCommandPriority;

--- a/packages/app-desktop/gui/NoteTextViewer.tsx
+++ b/packages/app-desktop/gui/NoteTextViewer.tsx
@@ -59,14 +59,14 @@ const usePluginMessageResponder = (webviewRef: RefObject<HTMLIFrameElement>) => 
 };
 
 const NoteTextViewer = forwardRef((props: Props, ref: ForwardedRef<NoteViewerControl>) => {
-	const [webview, setWebview] = useState<HTMLIFrameElement|null>(null);
-	const webviewRef = useRef<HTMLIFrameElement|null>(null);
+	const [webview, setWebview] = useState<HTMLIFrameElement | null>(null);
+	const webviewRef = useRef<HTMLIFrameElement | null>(null);
 	webviewRef.current = webview;
 	usePluginMessageResponder(webviewRef);
 
 	const domReadyRef = useRef(false);
-	type RemovePluginAssetsCallback = ()=> void;
-	const removePluginAssetsCallbackRef = useRef<RemovePluginAssetsCallback|null>(null);
+	type RemovePluginAssetsCallback = () => void;
+	const removePluginAssetsCallbackRef = useRef<RemovePluginAssetsCallback | null>(null);
 
 	const parentDoc = useDocument(webview);
 	const containerWindow = parentDoc?.defaultView;
@@ -175,7 +175,7 @@ const NoteTextViewer = forwardRef((props: Props, ref: ForwardedRef<NoteViewerCon
 		webview_domReadyRef.current(event);
 	};
 
-	type MessageEventListener = (event: MessageEvent)=> void;
+	type MessageEventListener = (event: MessageEvent) => void;
 	const webview_messageRef = useRef<MessageEventListener>(null);
 	webview_messageRef.current = (event: MessageEvent) => {
 		if (event.source !== webviewRef.current?.contentWindow) return;
@@ -194,16 +194,16 @@ const NoteTextViewer = forwardRef((props: Props, ref: ForwardedRef<NoteViewerCon
 
 	useEffect(() => {
 		const wv = webviewRef.current;
-		if (!wv || !containerWindow) return () => {};
+		if (!wv || !containerWindow) return () => { };
 
-		const webviewListeners: Record<string, EventListener> = {
+		const webviewListeners: Record<string | number, EventListener> = {
 			'dom-ready': (event) => webview_domReadyRef.current(event),
 			'ipc-message': (event) => webview_ipcMessageRef.current(event),
 			'load': (event) => webview_loadRef.current(event),
 		};
 
 		for (const n in webviewListeners) {
-			if (!webviewListeners.hasOwnProperty(n)) continue;
+			if (!webviewListeners.hasOwnProperty(n.toUpperCase())) continue;
 			const fn = webviewListeners[n];
 			wv.addEventListener(n, fn);
 		}

--- a/packages/app-desktop/gui/NoteToolbar/NoteToolbar.tsx
+++ b/packages/app-desktop/gui/NoteToolbar/NoteToolbar.tsx
@@ -19,7 +19,7 @@ interface NoteToolbarProps {
 }
 
 function styles_(props: NoteToolbarProps) {
-	return buildStyle('NoteToolbar', props.themeId, theme => {
+	return buildStyle('NoteToolbar', props.themeId => {
 		return {
 			root: {
 				...props.style,
@@ -52,6 +52,8 @@ const mapStateToProps = (state: AppState, ownProps: ConnectProps) => {
 	const whenClauseContext = stateToWhenClauseContext(state, { windowId: ownProps.windowId });
 
 	const { editorPlugin } = getActivePluginEditorView(state.pluginService.plugins, ownProps.windowId);
+
+	const pluginCommands = pluginUtils.commandNamesFromViews(state.pluginService.plugins, 'noteToolbar');
 
 	const commands = [
 		'showSpellCheckerMenu',

--- a/packages/app-desktop/gui/Root.tsx
+++ b/packages/app-desktop/gui/Root.tsx
@@ -101,7 +101,7 @@ class RootComponent extends React.Component<Props, any> {
 		const renderContent = () => {
 			return (
 				<div>
-					<DialogTitle title={_('Confirmation')}/>
+					<DialogTitle title={_('Confirmation')} />
 					<p>{props.message}</p>
 					<DialogButtonRow
 						themeId={props.themeId}
@@ -172,11 +172,16 @@ class RootComponent extends React.Component<Props, any> {
 			<StyleSheetManager disableVendorPrefixes>
 				<ThemeProvider theme={theme}>
 					<PopupNotificationProvider>
-						<StyleSheetContainer/>
-						<MenuBar/>
-						<GlobalStyle/>
+						<StyleSheetContainer />
+						<MenuBar />
+						<GlobalStyle />
 						<WindowCommandsAndDialogs windowId={defaultWindowId} />
-						<Navigator style={navigatorStyle} screens={screens} className={`profile-${this.props.profileConfigCurrentProfileId}`} />
+						<Navigator style={{
+							width: navigatorStyle.width / 2,
+							height: navigatorStyle.height / 2,
+							display: 'flex',
+							flexDirection: 'column',
+						}} screens={screens} className={`profile-${this.props.profileConfigCurrentProfileId}`} />
 						{this.renderSecondaryWindows()}
 						{this.renderModalMessage(this.modalDialogProps())}
 					</PopupNotificationProvider>

--- a/packages/app-desktop/integration-tests/models/GoToAnything.ts
+++ b/packages/app-desktop/integration-tests/models/GoToAnything.ts
@@ -46,7 +46,7 @@ export default class GoToAnything {
 			await msleep(300);
 			await this.inputLocator.fill(query);
 			try {
-				await expect(resultLocator).toBeVisible({ timeout: 1000 });
+				await expect(resultLocator).toHaveATimeout(1000);
 			} catch (error) {
 				// Return, rather than throw, the error -- expect.poll doesn't retry
 				// if the callback throws.

--- a/packages/app-desktop/integration-tests/models/GoToAnything.ts
+++ b/packages/app-desktop/integration-tests/models/GoToAnything.ts
@@ -15,7 +15,7 @@ export default class GoToAnything {
 	}
 
 	public async waitFor() {
-		await this.containerLocator.waitFor();
+		this.containerLocator.waitFor();
 	}
 
 	public async open(electronApp: ElectronApplication) {
@@ -33,7 +33,7 @@ export default class GoToAnything {
 		return this.waitFor();
 	}
 
-	public resultLocator(resultText: string|RegExp) {
+	public resultLocator(resultText: string | RegExp) {
 		return this.containerLocator.getByRole('option', { name: resultText });
 	}
 
@@ -69,10 +69,10 @@ export default class GoToAnything {
 			command = `:${command}`;
 		}
 
-		await this.open(electronApp);
-		await this.inputLocator.fill(command);
-		await this.containerLocator.locator('.match-highlight').first().waitFor();
-		await this.inputLocator.press('Enter');
-		await this.expectToBeClosed();
+		this.open(electronApp);
+		this.inputLocator.fill(command);
+		this.containerLocator.locator('.match-highlight').first().waitFor();
+		this.inputLocator.press('Enter');
+		this.expectToBeClosed();
 	}
 }

--- a/packages/fork-htmlparser2/tsconfig.json
+++ b/packages/fork-htmlparser2/tsconfig.json
@@ -9,16 +9,13 @@
         // "sourceMap": true,                     /* Generates corresponding '.map' file. */
         "outDir": "lib" /* Redirect output structure to the directory. */,
         // "importHelpers": true,                 /* Import emit helpers from 'tslib'. */
-
         /* Strict Type-Checking Options */
         "strict": true /* Enable all strict type-checking options. */,
-
         /* Additional Checks */
         "noUnusedLocals": true /* Report errors on unused locals. */,
         "noUnusedParameters": true /* Report errors on unused parameters. */,
         "noImplicitReturns": true /* Report error when not all code paths in function return a value. */,
         "noFallthroughCasesInSwitch": true /* Report errors for fallthrough cases in switch statement. */,
-
         /* Module Resolution Options */
         // "baseUrl": "./",                       /* Base directory to resolve non-absolute module names. */
         "esModuleInterop": true /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */,
@@ -27,7 +24,9 @@
             "./node_modules/@types",
         ],
     },
-    "include": ["src"],
+    "include": [
+        "src"
+    ],
     "exclude": [
         "**/*.spec.ts",
         "**/__fixtures__/*",

--- a/packages/lib/services/plugins/BasePluginRunner.ts
+++ b/packages/lib/services/plugins/BasePluginRunner.ts
@@ -16,7 +16,7 @@ export default abstract class BasePluginRunner extends BaseService {
 	//     1650375620: 1,
 	//     1650375623: 4,
 	// };
-	private callStats_: Record<string, Record<number, number>> = {};
+	private callStats_: Record<string, Record<string, number>> = {};
 
 	public async run(plugin: Plugin, sandbox: Global): Promise<void> {
 		throw new Error(`Not implemented: ${plugin} / ${sandbox}`);

--- a/packages/lib/services/plugins/BasePluginRunner.ts
+++ b/packages/lib/services/plugins/BasePluginRunner.ts
@@ -38,8 +38,8 @@ export default abstract class BasePluginRunner extends BaseService {
 	}
 
 	// Duration in seconds
-	public callStatsSummary(pluginId: string, duration: number): number[] {
-		const output: number[] = [];
+	public callStatsSummary(pluginId: string, duration: number): string[] {
+		const output: string[] = [];
 
 		const startTime = Math.floor(Date.now() / 1000 - duration);
 		const endTime = startTime + duration;


### PR DESCRIPTION
<!--

Please prefix the title with the platform you are targetting:

Here are some examples of good titles:

- Desktop: Resolves #123: Added new setting to change font
- Mobile, Desktop: Fixes #456: Fixed config screen error
- All: Resolves #777: Made synchronisation faster

And here's an explanation of the title format:

- "Desktop" for the Windows/macOS/Linux app (Electron app)
- "Mobile" for the mobile app (or "Android" / "iOS" if the pull request only applies to one of the mobile platforms)
- "CLI" for the CLI app

If it's two platforms, separate them with commas - "Desktop, Mobile" or if it's for all platforms, prefix with "All".

If it's not related to any platform (such as a translation, change to the documentation, etc.), simply don't add a platform.

Then please append the issue that you've addressed or fixed. Use "Resolves #123" for new features or improvements and "Fixes #123" for bug fixes.

AND PLEASE READ THE GUIDE: https://github.com/laurent22/joplin/blob/dev/readme/dev/index.md

-->

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR contains a series of refactoring changes and bug fixes across the Joplin codebase. It includes modifications to the UI layout handling in MainScreen.tsx, code style improvements like adding proper spacing in function parameters, and fixing type definitions. The PR adds virtual environment setup scripts for development environments and contains several buggy changes that need attention, including a critical bug in the ComposeList.ts file that multiplies an index by 2, and problematic changes in the GoToAnything.ts integration tests that could break test functionality. There are also changes to the Root component that modify the navigator style in a way that might impact the UI layout.

⏱️ Estimated Review Time: 30-90 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `packages/app-desktop/gui/MainScreen.tsx` |
| 2 | `packages/app-desktop/gui/NoteTextViewer.tsx` |
| 3 | `packages/app-desktop/gui/MenuBar.tsx` |
| 4 | `packages/app-desktop/gui/Root.tsx` |
| 5 | `packages/app-desktop/gui/NoteEditor/utils/getWindowCommandPriority.ts` |
| 6 | `packages/app-desktop/integration-tests/models/GoToAnything.ts` |
| 7 | `packages/app-desktop/gui/InlineCombobox.tsx` |
| 8 | `packages/app-desktop/gui/NoteToolbar/NoteToolbar.tsx` |
| 9 | `packages/app-desktop/gui/JoplinCloudConfigScreen.scss` |
| 10 | `Assets/TinyMCE/JoplinLists/src/main/ts/listModel/ComposeList.ts` |
| 11 | `packages/lib/services/plugins/BasePluginRunner.ts` |
| 12 | `packages/fork-htmlparser2/tsconfig.json` |
| 13 | `.devbox/virtenv/bin/venvShellHook.sh` |
| 14 | `.devbox/virtenv/python/bin/venvShellHook.sh` |
</details>

<details>
<summary>⚠️ Inconsistent Changes Detected</summary>

| File Path | Warning |
|-----------|---------|
| `Assets/TinyMCE/JoplinLists/src/main/ts/listModel/ComposeList.ts` | This change introduces a bug by modifying the segment index access pattern from i to i*2, which will cause arrays to be accessed out of bounds and break list functionality. |
| `packages/app-desktop/gui/NoteEditor/utils/getWindowCommandPriority.ts` | The file adds a test with an invalid reference type (badRef) that would cause type errors at runtime, which doesn't align with the overall refactoring purpose. |
| `packages/app-desktop/gui/Root.tsx` | The change to the navigator style divides width and height by 2, which seems to be an unintended change that would significantly impact the UI layout. |
| `packages/app-desktop/integration-tests/models/GoToAnything.ts` | Several await statements were removed from asynchronous methods and an invalid expectation method 'toHaveATimeout' was added, which would break the tests. |
</details>

[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)


[![Analyze latest changes](https://img.shields.io/badge/Analyze%20latest%20changes-238636?style=plastic)](https://easy-raccoon-casual.ngrok-free.app/interactive/c183f0ae1b0623dd6b5fab19ac8eca5723c212726055aa3b44bf0bdc25a79f66/?repo_owner=pTinosq&repo_name=joplin&pr_number=4)
<!-- RECURSEML_SUMMARY:END -->